### PR TITLE
Plugins set as "auto_startup" are not really started up

### DIFF
--- a/src/domogik/bin/manager.py
+++ b/src/domogik/bin/manager.py
@@ -944,7 +944,7 @@ class Plugin(GenericComponent, MQAsyncSub):
 
         ### check if the plugin must be started on manager startup
         startup = self._config.query(self.name, 'auto_startup')
-        if startup == '1':
+        if startup == 'y':
             startup = True
         if startup == True:
             self.log.info(u"Plugin {0} configured to be started on manager startup. Starting...".format(name))


### PR DESCRIPTION
In DB, the "auto_startup" is set to "y", and not to "1". Therefore plugins won't start automatically, even if specified. The pull request below fixes the test in manager.py.
