### PR TITLE
add missing gcc debian dependancy

### DIFF
--- a/debian_packages_install.sh
+++ b/debian_packages_install.sh
@@ -4,6 +4,7 @@ pkg_list="\
          alembic \
          mysql-server \
          gettext \
+         gcc\
          \
          python \
          python-setuptools \


### PR DESCRIPTION
I believe that you are missing the gcc dependency on debian system.
At least on my Jessie (docker based) system I need it to avoid error like :

```
unable to execute 'x86_64-linux-gnu-gcc': No such file or directory
error: Setup script exited with error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```
