### PR TITLE
add a command line option to skip database backup

### DIFF
--- a/install.py
+++ b/install.py
@@ -330,6 +330,8 @@ def install():
                    default=True, help='Don\'t create a user')
     parser.add_argument('--no-db-upgrade', dest='db', action="store_true",
                    default=False, help='Don\'t do a db upgrade')
+    parser.add_argument('--no-db-backup', dest='skip_database_backup', action="store_true",
+                   default=False, help='Don\'t do a db backup')
     parser.add_argument("--user",
                    help="Set the domogik user")
 
@@ -439,7 +441,7 @@ def install():
             dbi = DbInstall()
             if args.create_database:
                 dbi.create_db()
-            dbi.install_or_upgrade_db()
+            dbi.install_or_upgrade_db(args.skip_database_backup)
 
         # change permissions to some files created as root during the installation to the domogik user
         os.chown("/var/log/domogik/db_api.log", user_entry.pw_uid, -1)

--- a/src/domogik/install/db_install.py
+++ b/src/domogik/install/db_install.py
@@ -86,7 +86,7 @@ class DbInstall():
             ok("Done!");
 
 
-    def install_or_upgrade_db(self):
+    def install_or_upgrade_db(self, skip_backup=False):
         from domogik.common import sql_schema
         from domogik.common import database
         from sqlalchemy import create_engine, MetaData, Table
@@ -105,8 +105,9 @@ class DbInstall():
             command.stamp(self.alembic_cfg, "head")
             ok("Setting db version to head")
         else:
-            ok("Creating backup")
-            self.backup_existing_database()
+            if not skip_backup:
+                ok("Creating backup")
+                self.backup_existing_database()
             ok("Upgrading")
             command.upgrade(self.alembic_cfg, "head")
         return 


### PR DESCRIPTION
In the manual install process (not debian) I need a way to automate the install and haven't any prompt for user input. This option add the ability to skip the question for the db backup part and don't do it.

So setting this option : 
- do not prompt the user for a backup
- don't do a database backup
