### PR TITLE
Fix #144: Edit device boolean global param don't work

### DIFF
--- a/src/domogik/admin/themes/default/templates/client_global.html
+++ b/src/domogik/admin/themes/default/templates/client_global.html
@@ -4,7 +4,7 @@
 {% block content %}
 {% include theme("client_menu.html") %}
 <div class="container">
-    <h2>{% trans %}Edit the device GLOBAl parameters{% endtrans %}</h2>
+    <h2>{% trans %}Edit the device GLOBAL parameters{% endtrans %}</h2>
     {{ wtf.quick_form(form, add_submit=True, submit_title='Save') }}
 </div>
 {% endblock %}


### PR DESCRIPTION
WTForm BooleanField don't validate form in case of false value, so we must desactivate his validation.
It's not a real problem because value cam be only True/False and not empty.