### PR TITLE
Fix #337, replace 'elif' by 'else: if' in eval scenario

### DIFF
--- a/src/domogik/bin/scenario.py
+++ b/src/domogik/bin/scenario.py
@@ -55,7 +55,7 @@ class ScenarioFrontend(Plugin):
         mq_services = None
         while mq_services == None or 'xplgw' not in mq_services:
             mq_services_raw = cli.rawrequest('mmi.services', '', timeout=10)
-            if mq_services_raw != None: 
+            if mq_services_raw != None:
                 mq_services = str(mq_services_raw[0]).replace(" ", "").split(",")
             self.log.info("Checking for MQ services : {0}".format(mq_services))
             if mq_services == None or 'xplgw' not in mq_services:

--- a/src/domogik/scenario/manager.py
+++ b/src/domogik/scenario/manager.py
@@ -67,7 +67,7 @@ class ScenarioManager:
         The test on devices are managed directly by xpl Listeners
         The test on time will be managed by a TimeManager
         The actions will be managed by an ActionManager
-        { 
+        {
          "condition" :
             { "AND" : {
                     "OR" : {
@@ -139,13 +139,13 @@ class ScenarioManager:
                         msg = "Waiting for {0} seconds".format(DATABASE_CONNECTION_WAIT)
                         self.log.info(msg)
                         time.sleep(DATABASE_CONNECTION_WAIT)
-    
+
                 if nb_test >= DATABASE_CONNECTION_NUM_TRY:
                     msg = "Exiting dbmgr!"
                     self.log.error(msg)
                     self.force_leave()
                     return
-    
+
                 ### Do the stuff
                 msg = "Connected to the database"
                 self.log.info(msg)
@@ -233,10 +233,10 @@ class ScenarioManager:
         # create the condition itself
         try:
             scen = ScenarioInstance(self.log, cid, name, payload, dis, state, self._db)
-            self._instances[cid] = {'name': name, 'json': payload, 'instance': scen, 'disabled': dis } 
+            self._instances[cid] = {'name': name, 'json': payload, 'instance': scen, 'disabled': dis }
             self.log.debug(u"Create scenario instance {0} with payload {1}".format(name, payload))
             self._instances[cid]['instance'].eval_condition()
-        except Exception as e:  
+        except Exception as e:
             if int(ocid) == 0:
                 with self._db.session_scope():
                     self._db.del_scenario(cid)
@@ -341,7 +341,7 @@ class ScenarioManager:
             msg = u"Error while enabling the scenario id='{0}'. Error is : {1}".format(cid, traceback.format_exc())
             self.log.error(msg)
             return {'status': 'ERROR', 'msg': msg}
- 
+
     def disable_scenario(self, cid):
         try:
             if cid == '' or int(cid) not in self._instances.keys():

--- a/src/domogik/scenario/scenario.py
+++ b/src/domogik/scenario/scenario.py
@@ -38,7 +38,6 @@ from domogikmq.pubsub.subscriber import MQAsyncSub
 import zmq
 import traceback
 import logging
-import time
 import ast
 from domogik.common.utils import ucode
 
@@ -184,7 +183,6 @@ class ScenarioInstance(MQAsyncSub):
                 if a_kind_of_test.startswith("sensor.SensorTest"):
                     self._log.debug(u"Scenario '{0}' : test instance : {1} ({2} items)".format(remove_accents(self._name), a_kind_of_test, len(self._test_instances[a_kind_of_test])))
                     for idx, val in enumerate(self._test_instances[a_kind_of_test]):
-#                        if idx+1 != len(self._test_instances[a_kind_of_test]) :
                         if val.__class__.__name__ == 'SensorTest':
                             self._log.debug("Set trigger for item '{0}' to generic_trigger".format(idx))
                             val.set_trigger(self.generic_trigger)
@@ -424,7 +422,7 @@ class ScenarioInstance(MQAsyncSub):
         """ Dummy function to avoid calling self.generic_trigger() when not needed
             See _create_instance for more details
         """
-        self._log.debug(u"Dummy {0} escape trigger with value : {1}".format(foo._sensorId, foo._res))
+        self._log.debug(u"Dummy sensor {0} escape trigger with value : {1}".format(foo._sensorId, foo._res))
 
     def _create_instance(self, inst, itype, parentPart):
         uuid = self._get_uuid()

--- a/src/domogik/scenario/scenario.py
+++ b/src/domogik/scenario/scenario.py
@@ -251,14 +251,15 @@ class ScenarioInstance(MQAsyncSub):
                     num = int(ipart.replace('IF', ''))
                     if num == 0:
                         st = "print('---- Start evaluating ----')\nif"
-                        #st = "if"
+                        incLev = 1
                     else:
-                        st = "elif"
+                        st =  "{0}{1}".format(pyObj(u"else:\n", num-1), pyObj(u"if", num))
+                        incLev = 2 * num
                     # if stays at the same lvl
                     ifp = self.__parse_part(part["IF{0}".format(num)], level, debug)
                     retlist.append( pyObj(u"{0} {1}:\r\n".format(st, ifp), level) )
                     # do is a level deeper
-                    dop = self.__parse_part(part["DO{0}".format(num)], (level+1), debug)
+                    dop = self.__parse_part(part["DO{0}".format(num)], (level+incLev), debug)
                     retlist.append( pyObj(dop, level) )
             # handle ELSE
             if 'ELSE' in part:

--- a/src/domogik/scenario/scenario.py
+++ b/src/domogik/scenario/scenario.py
@@ -38,6 +38,7 @@ from domogikmq.pubsub.subscriber import MQAsyncSub
 import zmq
 import traceback
 import logging
+import time
 import ast
 from domogik.common.utils import ucode
 
@@ -177,18 +178,19 @@ class ScenarioInstance(MQAsyncSub):
             self._parsed_condition = self.__parse_part(self._json)
 
             # Set the trigger to the last test of each kind of test
+            # Only SensorTest class receive generic_trigger
             self._log.info(u"Scenario '{0}' : configure the trigger to the last item of each test instance".format(remove_accents(self._name)))
             for a_kind_of_test in self._test_instances:
                 if a_kind_of_test.startswith("sensor.SensorTest"):
                     self._log.debug(u"Scenario '{0}' : test instance : {1} ({2} items)".format(remove_accents(self._name), a_kind_of_test, len(self._test_instances[a_kind_of_test])))
                     for idx, val in enumerate(self._test_instances[a_kind_of_test]):
-                        if idx+1 != len(self._test_instances[a_kind_of_test]):
-                            self._log.debug("Set trigger for item '{0}' to dummy".format(idx))
-                            val.set_trigger(self._dummy)
-                        else:
+#                        if idx+1 != len(self._test_instances[a_kind_of_test]) :
+                        if val.__class__.__name__ == 'SensorTest':
                             self._log.debug("Set trigger for item '{0}' to generic_trigger".format(idx))
                             val.set_trigger(self.generic_trigger)
-
+                        else:
+                            self._log.debug("Set trigger for item '{0}' to dummy".format(idx))
+                            val.set_trigger(self._dummy)
 
             self._log.debug(u"Scenario '{0}' python generated code : \n{1}".format(remove_accents(self._name), self._parsed_condition))
             # this line is to decomment only for debug purpose
@@ -205,7 +207,7 @@ class ScenarioInstance(MQAsyncSub):
         except:
             raise
 
-    def __parse_part(self, part, level=0, debug=False):
+    def __parse_part(self, part, level=0, debug=False, parentPart=False):
         """Parse the json code and generate a python string that can be evaluated
         indentation needs to be done on the following objects:
         - do of an if part
@@ -213,6 +215,7 @@ class ScenarioInstance(MQAsyncSub):
         - get/set variables
         If debug=False, generate the python code for the scenario
         Else, generate a python code evaluated for debugging
+        If parentPart, change SensorTest as SensorValue class to avoid tiggerring not needed.
         """
         # Do not handle disabled blocks
         if 'disabled'in part and part['disabled'] == 'true':
@@ -246,6 +249,7 @@ class ScenarioInstance(MQAsyncSub):
         # parse the blocks
         if part['type'] == 'controls_if':
             # handle all Ifx and dox
+            incLev = 1 # Account for elif level to  indente an else if
             for ipart, val in sorted(part.items()):
                 if ipart.startswith('IF'):
                     num = int(ipart.replace('IF', ''))
@@ -254,20 +258,21 @@ class ScenarioInstance(MQAsyncSub):
                         incLev = 1
                     else:
                         st =  "{0}{1}".format(pyObj(u"else:\n", num-1), pyObj(u"if", num))
-                        incLev = 2 * num
+                        incLev = num + 1
                     # if stays at the same lvl
-                    ifp = self.__parse_part(part["IF{0}".format(num)], level, debug)
+                    ifp = self.__parse_part(part["IF{0}".format(num)], level, debug, False)
                     retlist.append( pyObj(u"{0} {1}:\r\n".format(st, ifp), level) )
                     # do is a level deeper
-                    dop = self.__parse_part(part["DO{0}".format(num)], (level+incLev), debug)
+                    dop = self.__parse_part(part["DO{0}".format(num)], (level+incLev), debug, True)
                     retlist.append( pyObj(dop, level) )
             # handle ELSE
             if 'ELSE' in part:
-                retlist.append( pyObj(u"else:\r\n", level) )
-                retlist.append( pyObj(self.__parse_part(part['ELSE'], (level+1), debug), (level)) )
+                incLev -= 1 # decrease elif level for final else, could be 0 if no elif
+                retlist.append( pyObj(u"else:\r\n", level+incLev) )
+                retlist.append( pyObj(self.__parse_part(part['ELSE'], (level+incLev+1), debug, parentPart), (level)) )
         # Set a local variable
         elif part['type'] == 'variables_set':
-            retlist.append( pyObj(u"{0}={1}\r\n".format(part['VAR'], self.__parse_part(part["VALUE"], level, debug)), level) )
+            retlist.append( pyObj(u"{0}={1}\r\n".format(part['VAR'], self.__parse_part(part["VALUE"], level, debug, parentPart)), level) )
         # get a local variable
         elif part['type'] == 'variables_get':
             retlist.append( pyObj(u"{0} if vars().has_key('{0}') else ''".format(part['VAR']), level) )
@@ -288,15 +293,15 @@ class ScenarioInstance(MQAsyncSub):
             reslst = []
             for ipart, val in sorted(part.items()):
                 if ipart.startswith('ADD'):
-                    addp = self.__parse_part(part[ipart], level, debug)
+                    addp = self.__parse_part(part[ipart], level, debug, parentPart)
                     reslst.append(u"str({0})".format(addp))
             retlist.append( pyObj(u" + ".join(reslst)) )
         # get the length of a string
         elif part['type'] == 'text_length':
-            retlist.append( pyObj(u"len({0})".format(self.__parse_part(part['VALUE'], level, debug))) )
+            retlist.append( pyObj(u"len({0})".format(self.__parse_part(part['VALUE'], level, debug, parentPart))) )
         # is the string empty
         elif part['type'] == 'text_isEmpty':
-            retlist.append( pyObj(u"not len({0})".format(self.__parse_part(part['VALUE'], level, debug))) )
+            retlist.append( pyObj(u"not len({0})".format(self.__parse_part(part['VALUE'], level, debug, parentPart))) )
         # do a calculation on 2 numbers
         elif part['type'] == 'math_arithmetic':
             if part['OP'].lower() == "add":
@@ -309,7 +314,7 @@ class ScenarioInstance(MQAsyncSub):
                 compare = "/"
             elif part['OP'].lower() == "power":
                 compare = "^"
-            retlist.append( pyObj(u"( {0} {1} {2} )".format(self.__parse_part(part['A'], level, debug), compare, self.__parse_part(part['B'], level, debug))) )
+            retlist.append( pyObj(u"( {0} {1} {2} )".format(self.__parse_part(part['A'], level, debug, parentPart), compare, self.__parse_part(part['B'], level, debug, parentPart))) )
         # logically compare 2 items
         elif part['type'] == 'logic_compare':
             if part['OP'].lower() == "eq":
@@ -324,16 +329,16 @@ class ScenarioInstance(MQAsyncSub):
                 compare = ">"
             elif part['OP'].lower() == "gte":
                 compare = ">="
-            retlist.append( pyObj(u"( {0} {1} {2} )".format(self.__parse_part(part['A'], level, debug), compare, self.__parse_part(part['B'], level, debug))) )
+            retlist.append( pyObj(u"( {0} {1} {2} )".format(self.__parse_part(part['A'], level, debug, parentPart), compare, self.__parse_part(part['B'], level, debug, parentPart))) )
         # logical operate (and, or, not)
         elif part['type'] == 'logic_operation':
-            retlist.append( pyObj(u"( {0} {1} {2} )".format(self.__parse_part(part['A'], level, debug), part['OP'].lower(), self.__parse_part(part['B'], level, debug))) )
+            retlist.append( pyObj(u"( {0} {1} {2} )".format(self.__parse_part(part['A'], level, debug, parentPart), part['OP'].lower(), self.__parse_part(part['B'], level, debug, parentPart))) )
         # a not function
         elif part['type'] == 'logic_negate':
-            retlist.append( pyObj(u"not {0}".format(self.__parse_part(part['BOOL'], level, debug))) )
+            retlist.append( pyObj(u"not {0}".format(self.__parse_part(part['BOOL'], level, debug, parentPart))) )
         # handle hysteresis
         elif part['type'] == "trigger.Hysteresis":
-            test = self._create_instance(part['type'], 'test')
+            test = self._create_instance(part['type'], 'test', parentPart)
             test[0].fill_parameters({"id.id": part['id']})
             if debug == False:
                 retlist.append( pyObj(u"if self._mapping['test']['{0}'].evaluate():\r\n".format(test[1]), level) )
@@ -341,21 +346,21 @@ class ScenarioInstance(MQAsyncSub):
                 retlist.append( eval(u"if self._mapping['test']['{0}'].evaluate():\r\n".format(test[1]), level) )
             nlevel = level
             level = level + 1
-            retlist.append( pyObj(u"{0}".format(self.__parse_part(part['Run'], level, debug))) )
+            retlist.append( pyObj(u"{0}".format(self.__parse_part(part['Run'], level, debug, parentPart))) )
         # apply an action
         elif "Action" in part['type']:
-            act = self._create_instance(part['type'], 'action')
+            act = self._create_instance(part['type'], 'action', parentPart)
             for p, v in part.items():
                 if p not in ['id', 'type', 'NEXT']:
                     if 'type' in v:
-                        v2 = ( self.__parse_part(v, 0, debug) )
+                        v2 = ( self.__parse_part(v, 0, debug, parentPart) )
                     else:
                         v2 = u"\"{0}\"".format(v)
                     retlist.append( pyObj(u"self._mapping['action']['{0}'].set_param(\"{1}\", ({2}))\r\n".format(act[1], p, v2), level) )
             retlist.append( pyObj(u"self._mapping['action']['{0}'].do_action()\r\n".format(act[1]), level) )
         # if we end up here we should be a test case
         else:
-            test = self._create_instance(part['type'], 'test')
+            test = self._create_instance(part['type'], 'test', parentPart)
             # test[0] : test object
             # test[1] : test uuid
 
@@ -379,7 +384,7 @@ class ScenarioInstance(MQAsyncSub):
                 retlist.append( eval(u"self._mapping['test']['{0}'].evaluate()".format(test[1])) )
         # handle the NEXT, so we can stack blocks
         if 'NEXT'in part:
-            retlist.append( pyObj(u"{0}".format(self.__parse_part(part['NEXT'], level if not nlevel else nlevel, debug))) )
+            retlist.append( pyObj(u"{0}".format(self.__parse_part(part['NEXT'], level if not nlevel else nlevel, debug, parentPart))) )
         # build the output string
         res = u""
         for ret in retlist:
@@ -419,9 +424,9 @@ class ScenarioInstance(MQAsyncSub):
         """ Dummy function to avoid calling self.generic_trigger() when not needed
             See _create_instance for more details
         """
-        pass
+        self._log.debug(u"Dummy {0} escape trigger with value : {1}".format(foo._sensorId, foo._res))
 
-    def _create_instance(self, inst, itype):
+    def _create_instance(self, inst, itype, parentPart):
         uuid = self._get_uuid()
         if itype == 'test':
             # To avoid triggering a scenario N times if it uses N times the same test, we register the used tests
@@ -444,10 +449,28 @@ class ScenarioInstance(MQAsyncSub):
                 param = None
 
             module_name = "domogik.scenario.tests.{0}".format(mod)
+            if parentPart : # Parent block is a DO for action, SensorTest must be redirect to SensorValue
+                # If SensorTest allready exist on IF, same Sensor stay in Test mode not Value, so a dummy became SensorTestDummy and not a SensorValueDummy.
+                # This 2 class are equivalante, so finale behavior is same between SensorTestDummy and SensorValueDummy.
+                if clas == 'SensorTest' : clas='SensorValue'  # force class as SensorValue to avoid trigger evaluation
+            objM = None
+            for i in self._mapping['test'] :
+                objM = self._mapping['test'][i]
+                if objM.__class__.__name__ == 'SensorTest' and objM._sensorId == param :
+                    self._log.debug(u"SensorTest for sensor {0} allready set, move to dummy instance".format(param))
+                    clas='SensorTestDummy' # force class as SensorTestDummy to avoid uncontrollable call order update
+                    break
+                elif objM.__class__.__name__ == 'SensorValue' and objM._sensorId == param :
+                    self._log.debug(u"SensorValue for sensor {0} allready set, move to dummy instance".format(param))
+                    clas='SensorValueDummy' # force class as SensorValueDummy to avoid uncontrollable call order update
+                    break
+                else :
+                    objM = None
             cobj = getattr(__import__(module_name, fromlist=[mod]), clas)
             self._log.debug(u"Create test instance {0} with uuid {1}".format(inst, uuid))
             #obj = cobj(log=self._log, trigger=self.generic_trigger, cond=self, params=param)
             obj = cobj(log=self._log, trigger=trigger, cond=self, params=param)
+            if objM is not None : objM.register_dummy(obj)
             self._subList = self._subList + obj.get_subMessages()
             self._mapping['test'][uuid] = obj
             return (obj, uuid)
@@ -458,6 +481,7 @@ class ScenarioInstance(MQAsyncSub):
                 mod, clas = inst.split('.')
                 params = None
             module_name = "domogik.scenario.actions.{0}".format(mod)
+
             cobj = getattr(__import__(module_name, fromlist=[mod]), clas)
             self._log.debug(u"Create action instance {0} with uuid {1}".format(inst, uuid))
             obj = cobj(log=self._log, params=params)
@@ -481,7 +505,6 @@ class ScenarioInstance(MQAsyncSub):
         pass
 
     def generic_trigger(self, test):
-        self.eval_condition()
         #if test.get_condition():
         #    cond = test.get_condition()
         #    if cond.get_parsed_condition() is None:
@@ -489,6 +512,7 @@ class ScenarioInstance(MQAsyncSub):
         #    st = cond.eval_condition()
         #else:
         #    test.evaluate()
+        self.eval_condition()
 
 class pyObj:
     """

--- a/src/domogik/scenario/tests/sensor.py
+++ b/src/domogik/scenario/tests/sensor.py
@@ -28,6 +28,7 @@ along with Domogik. If not, see U{http://www.gnu.org/licenses}.
 from domogik.scenario.tests.abstract import AbstractTest
 from domogik.common.database import DbHelper
 from time import sleep, time
+import threading
 import zmq
 
 class AbstractSensorTest(AbstractTest):
@@ -64,13 +65,13 @@ class AbstractSensorTest(AbstractTest):
         if self._sensorId:
             if 'sensor_id' in msg:
                 if int(msg['sensor_id']) == int(self._sensorId):
-                    self.log.debug(u"SensorTest : received MQ message : {0}. Please notice that if a scenario which use several of this sensor block is currently being evaluated, only one value is processed (in case the sensor values change too fast!)".format(msg))
+                    self.log.debug(u"{0} : received MQ message : {1}. Please notice that if a scenario which use several of this sensor block is currently being evaluated, only one value is processed (in case the sensor values change too fast!)".format(self.__class__.__name__, msg))
                     self.handle_message(did, msg)
 
 
 
 class SensorTest(AbstractSensorTest):
-    """ Sensor test : evaluate a sensor 
+    """ Sensor test : evaluate a sensor
     # params == the sensorId to check the value for
     """
 
@@ -81,11 +82,14 @@ class SensorTest(AbstractSensorTest):
         self._time = time()
         self._res_old = None
         self._time_old = None
+        self._dummies = []
 
     def handle_message(self, did, msg):
         self._time = time()
         self._res = self._convert(msg['stored_value'])
-        self.log.debug(u"SensorTest : Set sensor value = '{0}' for sensor id '{1}'. Trigger raised! Please notice that if a scenario which use several of this sensor block is currently being evaluated, only one trigger is processed to avoid running several times the same test.".format(self._res, self._sensorId))
+        self.log.debug(u"{0} : Set sensor value = '{1}' for sensor id '{2}'. Trigger raised! Please notice that if a scenario which use several of this sensor block is currently being evaluated, only one trigger is processed to avoid running several times the same test.".format(self.__class__.__name__, self._res, self._sensorId))
+        for dummy in self._dummies :
+            dummy.handle_message(did, msg, self._time)
         self._trigger(self)
 
     def _convert(self, val):
@@ -125,7 +129,7 @@ class SensorTest(AbstractSensorTest):
         usage = u.evaluate()
 
         if usage == "value":
-            self.log.debug(u"Evaluate SensorTest '{0}' in mode '{1}' to '{2}'. Type is '{3}'".format(self._sensorId, usage, self._res, type(self._res))) 
+            self.log.debug(u"Evaluate {0} '{1}' in mode '{2}' to '{3}'. Type is '{4}'".format(self.__class__.__name__,self._sensorId, usage, self._res, type(self._res)))
             self._res_old = self._res
             self._time_old = self._time
             return self._res
@@ -134,7 +138,7 @@ class SensorTest(AbstractSensorTest):
                 has_changed = True
             else:
                 has_changed = False
-            self.log.debug(u"Evaluate SensorTest '{0}' in mode '{1}' to '{2}'. Type is '{3}'".format(self._sensorId, usage, has_changed, type(has_changed))) 
+            self.log.debug(u"Evaluate {0} '{1}' in mode '{2}' to '{3}'. Type is '{4}'".format(self.__class__.__name__,self._sensorId, usage, has_changed, type(has_changed)))
             self._res_old = self._res
             self._time_old = self._time
             return has_changed
@@ -142,7 +146,7 @@ class SensorTest(AbstractSensorTest):
             #print("R vs Ro : {0} vs {1}".format(self._res, self._res_old))
             #print("T vs To : {0} vs {1}".format(self._time, self._time_old))
             if self._res_old != None and ((self._res != self._res_old) or (self._time != self._time_old)):   # not sensor startup or sensor value changed or date changed
-                self.log.debug(u"Evaluate SensorTest '{0}' in mode '{1}' to '{2}'. Type is '{3}'".format(self._sensorId, usage, True, type(True))) 
+                self.log.debug(u"Evaluate {0} '{1}' in mode '{2}' to '{3}'. Type is '{4}'".format(self.__class__.__name__, self._sensorId, usage, True, type(True)))
                 self._res_old = self._res
                 self._time_old = self._time
                 return True
@@ -154,5 +158,56 @@ class SensorTest(AbstractSensorTest):
             self.log.error(u"Bad usage used for sensorTest! Usage choosed ='{0}'".format(usage))
             return None
 
+    def register_dummy(self, dummy):
+        """ Register a dummy test to push updted value """
+        if dummy not in self._dummies :
+            self._dummies.append(dummy)
 
+class SensorTestDummy(SensorTest):
+    """ Sensor test : evaluate a sensor by cloning (dummy) a main SensorTest
+    # params == the sensorId to check the value for
+    """
 
+    def __init__(self, log = None, trigger = None, cond = None, params = None):
+        SensorTest.__init__(self, log, trigger, cond, params)
+        self._subMessages = [] # disable  'device-stats'   MQ Message
+
+    def on_message(self, did, msg):
+        pass
+
+    def handle_message(self, did, msg, time=0):
+        self._time = time
+        self._res = self._convert(msg['stored_value'])
+        self.log.debug(u"{0} : Set sensor value = '{1}' for sensor id '{2}'.".format(self.__class__.__name__, self._res, self._sensorId))
+
+class SensorValue(SensorTest):
+    """ Sensor Value : evaluate a sensor without triggering scenario evaluation
+    # params == the sensorId to check the value for
+    """
+
+    def __init__(self, log = None, trigger = None, cond = None, params = None):
+        SensorTest.__init__(self, log, trigger, cond, params)
+
+    def handle_message(self, did, msg):
+        self._time = time()
+        self._res = self._convert(msg['stored_value'])
+        self.log.debug(u"{0} : Set sensor value = '{1}' for sensor id '{2}'. No trigger evaluation need.".format(self.__class__.__name__, self._res, self._sensorId))
+        for dummy in self._dummies :
+            dummy.handle_message(did, msg, self._time)
+
+class SensorValueDummy(SensorValue):
+    """ Sensor Value : evaluate a sensor by cloning (dummy) a main SensorValue
+    # params == the sensorId to check the value for
+    """
+
+    def __init__(self, log = None, trigger = None, cond = None, params = None):
+        SensorValue.__init__(self, log, trigger, cond, params)
+        self._subMessages = [] # disable  'device-stats'   MQ Message
+
+    def on_message(self, did, msg):
+        pass
+
+    def handle_message(self, did, msg, time=0):
+        self._time = time
+        self._res = self._convert(msg['stored_value'])
+        self.log.debug(u"{0} : Set sensor value = '{1}' for sensor id '{2}'.".format(self.__class__.__name__, self._res, self._sensorId))

--- a/src/domogik/scenario/tests/sensor.py
+++ b/src/domogik/scenario/tests/sensor.py
@@ -28,7 +28,6 @@ along with Domogik. If not, see U{http://www.gnu.org/licenses}.
 from domogik.scenario.tests.abstract import AbstractTest
 from domogik.common.database import DbHelper
 from time import sleep, time
-import threading
 import zmq
 
 class AbstractSensorTest(AbstractTest):


### PR DESCRIPTION
elif in eval is bad evalution :  http://stackoverflow.com/questions/16247212/expression-evaluation-in-if-elif-statements

new scenario becam :+1: 

```
print('---- Start evaluating ----')
if ( self._mapping['test']['41b4f32a-b7b6-43ec-b402-5c2eb7bd15c5'].evaluate() == "OL" ):
    self._mapping['action']['0-0924ef60-9c57-4778-a50d-6c0bb1ebfe65'].set_param("body", ("Onduleur sur réseaux"))
    self._mapping['action']['0-0924ef60-9c57-4778-a50d-6c0bb1ebfe65'].do_action()
else:
    if ( self._mapping['test']['28e2fad2-307b-4af8-8a23-36ea4a82d988'].evaluate() == "OB" ):
        self._mapping['action']['1-6f63696c-ff45-4564-9325-ab097010392b'].set_param("body", ("Onduleur sur batterie"))
        self._mapping['action']['1-6f63696c-ff45-4564-9325-ab097010392b'].do_action()
    else:
        if ( self._mapping['test']['e6e7a7d8-6d34-41a6-b9b0-d6fc51e4e0f7'].evaluate() == "LB" ):
                self._mapping['action']['2-559b15fd-4ed2-4dd8-8252-0f429c45fb93'].set_param("body", ("Onduleur déconnecté"))
                self._mapping['action']['2-559b15fd-4ed2-4dd8-8252-0f429c45fb93'].do_action()

```