### PR TITLE
Add MQ REQ sensor_history.get: get the filtered and calculated histor…

### DIFF
--- a/src/domogik/bin/admin.py
+++ b/src/domogik/bin/admin.py
@@ -1110,13 +1110,15 @@ class Admin(Plugin):
                 mode = "last"
             elif msg_data['mode'] == "period":
                 mode = "period"
+            elif msg_data['mode'] == "filter":
+                mode = "filter"
             else:
-                reason = "ERROR when getting sensor history. No valid type (last, from) declared in the message"
+                reason = "ERROR when getting sensor history. No valid mode (last, period, filter) declared in the message"
                 self.log.error(reason)
                 status = False
                 mode = None
         else:
-            reason = "ERROR when getting sensor history. No type (last, from) declared in the message"
+            reason = "ERROR when getting sensor history. No mode (last, from, filter) declared in the message"
             self.log.error(reason)
             status = False
             sensor_id = None
@@ -1161,7 +1163,53 @@ class Admin(Plugin):
 
             else:
                 values = db.list_sensor_history_between(sensor_id, frm, to)
-        
+
+        ### filter
+        elif mode == "filter":
+            if 'from' in msg_data:
+                frm = msg_data['from']
+            else:
+                reason = "ERROR when getting sensor history. No key 'from' defined for mode = 'filter'!"
+                self.log.error(reason)
+                status = False
+                frm = None
+
+            if 'to' in msg_data:
+                to = msg_data['to']
+            else:
+                to = None
+
+            if 'interval' in msg_data:
+                interval = msg_data['interval']
+                if interval not in ('minute', 'hour', 'day', 'week', 'month', 'year'):
+                    reason = "ERROR when getting sensor history. key 'interval' should be one of : minute, hour, day, week, month, year for mode = 'filter'!"
+                    self.log.error(reason)
+                    status = False
+                    interval = None
+            else:
+                reason = "ERROR when getting sensor history. No key 'interval' defined for mode = 'filter'!"
+                self.log.error(reason)
+                status = False
+                interval = None
+
+            if 'selector' in msg_data:
+                selector = msg_data['selector']
+                if selector not in ('min', 'max', 'avg', 'sum'):
+                    reason = "ERROR when getting sensor history. key 'selector' should be one of : min, max, avg, sum for mode = 'filter'!"
+                    self.log.error(reason)
+                    status = False
+                    selector = None
+            else:
+                reason = "ERROR when getting sensor history. No key 'selector' defined for mode = 'filter'!"
+                self.log.error(reason)
+                status = False
+                interval = None
+
+            if frm != None and interval != None and selector != None:
+                values = db.list_sensor_history_filter(sensor_id, frm, to, interval, selector)  # fonctions dans database.py
+            else:
+                values = None
+
         msg.add_data('status', status)
         msg.add_data('reason', reason)
         msg.add_data('sensor_id', sensor_id)

--- a/src/domogik/examples/mq-python/req_sensor_history.py
+++ b/src/domogik/examples/mq-python/req_sensor_history.py
@@ -110,3 +110,13 @@ msg.add_data('mode', 'period')
 msg.add_data('from', 1449178465)
 print(cli.request('admin', msg.get(), timeout=10).get())
 
+# example 4 : get the filtered and calculated history starting from/to a certain timestamp
+msg = MQMessage()
+msg.set_action('sensor_history.get')
+msg.add_data('sensor_id', 141)
+msg.add_data('mode', 'filter')      # Like REST functions sensorHistory_from_filter and sensorHistory_from_to_filter
+msg.add_data('from', 1483225200)    #
+msg.add_data('to', 1500847199)      # Optionnal
+msg.add_data('interval', 'day')     # 'minute|hour|day|week|month|year'
+msg.add_data('selector', 'min')     # 'min|max|avg|sum'
+print(cli.request('admin', msg.get(), timeout=10).get())


### PR DESCRIPTION
Add MQ REQ sensor_history.get: 
Get the filtered and calculated history starting from/to a certain timestamp.
Like REST functions sensorHistory_from_filter and sensorHistory_from_to_filter

See "src/domogik/examples/mq-python/req_sensor_history.py" example #4 for usage.