### PR TITLE
Add domogik.service and dependencies for systemd purpose under debian

### DIFF
--- a/src/domogik/examples/systemd/system/domogik-mq-broker.service
+++ b/src/domogik/examples/systemd/system/domogik-mq-broker.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Domogik MQ Broker
+Documentation=http://domogik.readthedocs.io/en/master/
+Before=domogik.service domogik-mq-forwarder.service domogik-xpl.service
+PartOf=domogik.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/default/domogik-mq
+ExecStart=/usr/local/bin/dmg_broker
+User=domogik
+StandardOutput=null
+StandardError=null
+KillSignal=15
+
+[Install]
+WantedBy=multi-user.target

--- a/src/domogik/examples/systemd/system/domogik-mq-forwarder.service
+++ b/src/domogik/examples/systemd/system/domogik-mq-forwarder.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Domogik MQ Forwarder
+Documentation=http://domogik.readthedocs.io/en/master/
+Before=domogik.service domogik-xpl.service
+After=domogik-mq-broker.service
+PartOf=domogik.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/default/domogik-mq
+ExecStart=/usr/local/bin/dmg_forwarder
+User=domogik
+StandardOutput=null
+StandardError=null
+
+[Install]
+WantedBy=multi-user.target

--- a/src/domogik/examples/systemd/system/domogik-xpl.service
+++ b/src/domogik/examples/systemd/system/domogik-xpl.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Domogik Xpl Hub
+Documentation=http://domogik.readthedocs.io/en/master/
+Before=domogik.service
+After=domogik-mq-broker.service domogik-mq-forwarder.service
+PartOf=domogik.service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/default/domogik-mq
+ExecStart=/usr/local/bin/dmg_hub
+User=domogik
+StandardOutput=null
+StandardError=null
+
+[Install]
+WantedBy=multi-user.target

--- a/src/domogik/examples/systemd/system/domogik.service
+++ b/src/domogik/examples/systemd/system/domogik.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Domogik daemon
+Documentation=http://domogik.readthedocs.io/en/master/
+Before=shutdown.target
+After=domogik-mq-broker.service domogik-mq-forwarder.service domogik-xpl.service
+Requires=domogik-mq-broker.service domogik-mq-forwarder.service domogik-xpl.service
+BindsTo=domogik-mq-broker.service domogik-mq-forwarder.service domogik-xpl.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/default/domogik
+ExecStart=/usr/local/bin/dmg_manager -a -d -x -s -b
+User=domogik
+RuntimeDirectory=domogik
+PIDFile=/var/run/domogik/manager.pid
+Environment=PATH=$PATH:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+StandardOutput=null
+StandardError=null
+
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Files that can be use for domogik with dependencies and systemd daemon under debian.
System command to use with systemctl :
`systemctl daemon-reload
systemctl enable domogik*
systemctl start domogik.service`
